### PR TITLE
feat: implement registration CSV download endpoint

### DIFF
--- a/src/routes/regdownload/+server.ts
+++ b/src/routes/regdownload/+server.ts
@@ -1,0 +1,28 @@
+import { db } from '$lib/server/db';
+import { registration } from '$lib/server/db/schema';
+import type { RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async () => {
+	// 1. Fetch all registrations
+	const rows = await db.select().from(registration);
+
+	// 2. Convert to CSV
+	if (rows.length === 0) {
+		return new Response('No registrations found', { status: 404 });
+	}
+
+	const header = Object.keys(rows[0]).join(',');
+	const csvRows = rows.map((row) =>
+		Object.values(row).map((v) => (v === null ? '' : String(v).replace(/"/g, '""'))).join(',')
+	);
+
+	const csv = [header, ...csvRows].join('\n');
+
+	// 3. Return as downloadable CSV
+	return new Response(csv, {
+		headers: {
+			'Content-Type': 'text/csv; charset=utf-8',
+			'Content-Disposition': 'attachment; filename="registrations.csv"'
+		}
+	});
+};


### PR DESCRIPTION
Details

Added: src/routes/regdonload/+server.ts
Queries registration table with Drizzle ORM (db.select().from(registration))
Builds a CSV string with headers + rows
Handles null values gracefully
Escapes double quotes to maintain CSV compatibility
Sets appropriate response headers to return as a downloadable file
Endpoint available at: [/regdonload](http://localhost:5173/regdonload)